### PR TITLE
small change

### DIFF
--- a/lib/AWS/EC2/instances.rb
+++ b/lib/AWS/EC2/instances.rb
@@ -238,7 +238,7 @@ module AWS
     # Example Class Method Usage :
     # instance_id = AWS::EC2::Instance.local_instance_id
     #
-    module Instance
+    class Instance
 
       EC2_META_URL_BASE = 'http://169.254.169.254/latest/meta-data/'
 


### PR DESCRIPTION
Glen,

A while ago we discussed some additional parsing of EC2 instance meta data returned by describe_instance, etc. and we both agreed it might be better in the context of an external gem as the maintenance issues and application space design issues it raises.

I've been working on ec2-instance gem, and it's not much at this point, and probably won't be for a while.  Nonetheless I am going to play around with making an Instance class which contains the meta data and maybe some methods for returning sets of Instance objects etc.  

So this small change is just changing the Instance Module into an Instance class, with class methods.  There should be no impact on the current gem, I've grepped for any reference in extending with the Instance Module.

Your call if you think this change might upset anyone's systems -- I can live without it, but would be helpful.

-Robert
