### PR TITLE
Eucalyptus compatibility patch

### DIFF
--- a/amazon-ec2.gemspec
+++ b/amazon-ec2.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Glenn Rempe"]
-  s.date = %q{2010-11-12}
+  s.date = %q{2010-06-10}
   s.description = %q{A Ruby library for accessing the Amazon Web Services EC2, ELB, RDS, Cloudwatch, and Autoscaling APIs.}
   s.email = %q{glenn@rempe.us}
-  s.executables = ["setup.rb", "awshell", "ec2sh", "ec2-gem-example.rb", "ec2-gem-profile.rb"]
+  s.executables = ["ec2-gem-example.rb", "ec2-gem-profile.rb", "ec2sh", "setup.rb"]
   s.extra_rdoc_files = [
     "ChangeLog",
      "LICENSE",
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
      "Rakefile",
      "VERSION",
      "amazon-ec2.gemspec",
-     "bin/awshell",
      "bin/ec2-gem-example.rb",
      "bin/ec2-gem-profile.rb",
      "bin/ec2sh",
@@ -101,27 +100,27 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Amazon EC2 Ruby Gem}
   s.test_files = [
-    "test/test_EC2_spot_prices.rb",
-     "test/test_EC2_subnets.rb",
+    "test/test_Autoscaling_groups.rb",
+     "test/test_EC2.rb",
      "test/test_EC2_availability_zones.rb",
-     "test/test_EC2_security_groups.rb",
-     "test/test_EC2_instances.rb",
+     "test/test_EC2_console.rb",
+     "test/test_EC2_elastic_ips.rb",
      "test/test_EC2_image_attributes.rb",
      "test/test_EC2_images.rb",
-     "test/test_EC2.rb",
-     "test/test_EC2_responses.rb",
-     "test/test_EC2_volumes.rb",
-     "test/test_EC2_console.rb",
-     "test/test_EC2_snapshots.rb",
-     "test/test_ELB_load_balancers.rb",
-     "test/test_EC2_elastic_ips.rb",
-     "test/test_EC2_products.rb",
-     "test/test_RDS.rb",
-     "test/test_EC2_s3_xmlsimple.rb",
-     "test/test_helper.rb",
+     "test/test_EC2_instances.rb",
      "test/test_EC2_keypairs.rb",
+     "test/test_EC2_products.rb",
+     "test/test_EC2_responses.rb",
+     "test/test_EC2_s3_xmlsimple.rb",
+     "test/test_EC2_security_groups.rb",
+     "test/test_EC2_snapshots.rb",
      "test/test_EC2_spot_instance_requests.rb",
-     "test/test_Autoscaling_groups.rb"
+     "test/test_EC2_spot_prices.rb",
+     "test/test_EC2_subnets.rb",
+     "test/test_EC2_volumes.rb",
+     "test/test_ELB_load_balancers.rb",
+     "test/test_helper.rb",
+     "test/test_RDS.rb"
   ]
 
   if s.respond_to? :specification_version then

--- a/amazon-ec2.gemspec
+++ b/amazon-ec2.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Glenn Rempe"]
-  s.date = %q{2010-06-10}
+  s.date = %q{2010-11-12}
   s.description = %q{A Ruby library for accessing the Amazon Web Services EC2, ELB, RDS, Cloudwatch, and Autoscaling APIs.}
   s.email = %q{glenn@rempe.us}
-  s.executables = ["ec2-gem-example.rb", "ec2-gem-profile.rb", "ec2sh", "setup.rb"]
+  s.executables = ["setup.rb", "awshell", "ec2sh", "ec2-gem-example.rb", "ec2-gem-profile.rb"]
   s.extra_rdoc_files = [
     "ChangeLog",
      "LICENSE",
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
      "Rakefile",
      "VERSION",
      "amazon-ec2.gemspec",
+     "bin/awshell",
      "bin/ec2-gem-example.rb",
      "bin/ec2-gem-profile.rb",
      "bin/ec2sh",
@@ -100,27 +101,27 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Amazon EC2 Ruby Gem}
   s.test_files = [
-    "test/test_Autoscaling_groups.rb",
-     "test/test_EC2.rb",
+    "test/test_EC2_spot_prices.rb",
+     "test/test_EC2_subnets.rb",
      "test/test_EC2_availability_zones.rb",
-     "test/test_EC2_console.rb",
-     "test/test_EC2_elastic_ips.rb",
+     "test/test_EC2_security_groups.rb",
+     "test/test_EC2_instances.rb",
      "test/test_EC2_image_attributes.rb",
      "test/test_EC2_images.rb",
-     "test/test_EC2_instances.rb",
-     "test/test_EC2_keypairs.rb",
-     "test/test_EC2_products.rb",
+     "test/test_EC2.rb",
      "test/test_EC2_responses.rb",
-     "test/test_EC2_s3_xmlsimple.rb",
-     "test/test_EC2_security_groups.rb",
-     "test/test_EC2_snapshots.rb",
-     "test/test_EC2_spot_instance_requests.rb",
-     "test/test_EC2_spot_prices.rb",
-     "test/test_EC2_subnets.rb",
      "test/test_EC2_volumes.rb",
+     "test/test_EC2_console.rb",
+     "test/test_EC2_snapshots.rb",
      "test/test_ELB_load_balancers.rb",
+     "test/test_EC2_elastic_ips.rb",
+     "test/test_EC2_products.rb",
+     "test/test_RDS.rb",
+     "test/test_EC2_s3_xmlsimple.rb",
      "test/test_helper.rb",
-     "test/test_RDS.rb"
+     "test/test_EC2_keypairs.rb",
+     "test/test_EC2_spot_instance_requests.rb",
+     "test/test_Autoscaling_groups.rb"
   ]
 
   if s.respond_to? :specification_version then

--- a/bin/setup.rb
+++ b/bin/setup.rb
@@ -17,7 +17,17 @@ if ENV['AMAZON_ACCESS_KEY_ID'] && ENV['AMAZON_SECRET_ACCESS_KEY']
   }
 
   if ENV['EC2_URL']
-    opts[:server] = URI.parse(ENV['EC2_URL']).host
+    ec2uri = URI.parse(ENV['EC2_URL'])
+    opts[:server] = ec2uri.host
+    if ec2uri.path.downcase.include?("eucalyptus")
+	opts[:path] = ec2uri.path
+	opts[:port] = ec2uri.port
+	if ec2uri.class == URI::HTTPS 
+		opts[:use_ssl] = true
+	else
+		opts[:use_ssl] = false
+	end
+    end
     @ec2 = AWS::EC2::Base.new(opts)
   else
     @ec2 = AWS::EC2::Base.new(opts)

--- a/lib/AWS.rb
+++ b/lib/AWS.rb
@@ -126,12 +126,14 @@ module AWS
                   :secret_access_key => "",
                   :use_ssl => true,
                   :server => default_host,
+		  :path => "/",
                   :proxy_server => nil
                   }.merge(options)
 
       @server = options[:server]
       @proxy_server = options[:proxy_server]
       @use_ssl = options[:use_ssl]
+      @path = options[:path]
 
       raise ArgumentError, "No :access_key_id provided" if options[:access_key_id].nil? || options[:access_key_id].empty?
       raise ArgumentError, "No :secret_access_key provided" if options[:secret_access_key].nil? || options[:secret_access_key].empty?
@@ -248,7 +250,7 @@ module AWS
             CGI::escape(param[0]) + "=" + CGI::escape(param[1])
           end.join("&") + "&Signature=" + sig
 
-          req = Net::HTTP::Post.new("/")
+          req = Net::HTTP::Post.new(@path)
           req.content_type = 'application/x-www-form-urlencoded'
           req['User-Agent'] = "github-amazon-ec2-ruby-gem"
 
@@ -265,7 +267,7 @@ module AWS
 
       # Set the Authorization header using AWS signed header authentication
       def get_aws_auth_param(params, secret_access_key, server)
-        canonical_string =  AWS.canonical_string(params, server)
+        canonical_string =  AWS.canonical_string(params, server,"POST", @path)
         encoded_canonical = AWS.encode(secret_access_key, canonical_string)
       end
 


### PR DESCRIPTION
Hi Glenn,

This is the patch to make the library to be compatible with Eucalyptus. 
The patch is straightforward:
- Instead of having hard coded "/" as URL path, the path can be given to as an option.
- Setup.rb is changed such that server, port, path, and use_ssl can be correctly set up 

Thanks and let me know if you need any help!
- Sang-Min (spark@eucalyptus.com)
