### PR TITLE
Support for the ClientToken request parameter to the RunInstances API call

### DIFF
--- a/lib/AWS/EC2/instances.rb
+++ b/lib/AWS/EC2/instances.rb
@@ -23,6 +23,7 @@ module AWS
       # @option options [optional, Boolean] :disable_api_termination (true) Specifies whether the instance can be terminated using the APIs. You must modify this attribute before you can terminate any "locked" instances from the APIs.
       # @option options [optional, String] :instance_initiated_shutdown_behavior ('stop') Specifies whether the instance's Amazon EBS volumes are stopped or terminated when the instance is shut down. Valid values : 'stop', 'terminate'
       # @option options [optional, Boolean] :base64_encoded (false)
+      # @option options [optional, String] :client_token (nil) Unique, case-sensitive identifier you provide to ensure idempotency of the request
       #
       def run_instances( options = {} )
         options = { :image_id => "",
@@ -68,6 +69,7 @@ module AWS
         params["SubnetId"]                          = options[:subnet_id] unless options[:subnet_id].nil?
         params["DisableApiTermination"]             = options[:disable_api_termination].to_s unless options[:disable_api_termination].nil?
         params["InstanceInitiatedShutdownBehavior"] = options[:instance_initiated_shutdown_behavior] unless options[:instance_initiated_shutdown_behavior].nil?
+        params["ClientToken"]                       = options[:client_token].to_s unless options[:client_token].nil?
 
         return response_generator(:action => "RunInstances", :params => params)
       end

--- a/lib/AWS/EC2/tags.rb
+++ b/lib/AWS/EC2/tags.rb
@@ -4,8 +4,12 @@ module AWS
 
       # The CreateTags operation adds or overwrites tags for the specified resource(s).
       #
+      # @example Tag instance i-123456789 with the name 'Test Instance'.
+      #   create_tags(:resource_id => 'i-123456789',
+      #               :tag         => [{'Name' => 'Test Instance'}])
+      #
       # @option options [Array] :resource_id ([]) The ids of the resource(s) to tag
-      # @option options [Array] :tag ([]) An array of Hashes representing the tags { tag_name => tag_value }. Use nil or empty string to get a tag without a value
+      # @option options [Array] :tag ([]) An array of Hashes representing the tags as string name/value pairs. Use <tt>nil</tt> or empty string to get a tag without a value
       #
       def create_tags( options = {} )
         raise ArgumentError, "No :resource_id provided" if options[:resource_id].nil? || options[:resource_id].empty?
@@ -16,9 +20,14 @@ module AWS
         return response_generator(:action => "CreateTags", :params => params)
       end
 
-      # The DescribeTags operation lists the tags, If you do not specify any filters, all tags will be returned.
+      # The DescribeTags operation lists the tags. If you do not specify any filters, all tags will be returned.
       #
-      # @option options [optional, Array] :filter ([]) An array of Hashes representing the filters. Note that the values in the hashes have to be arrays. E.g. [{:key => ['name']}, {:resource_type => ['instance']},...]
+      # @example Find any instances tagged with the name 'Test Instance'.
+      #   describe_tags(:filter => [{'resource-type' => ['instance']},
+      #                             {'key'           => ['Name']},
+      #                             {'value'         => ['Test Instance']}])
+      #
+      # @option options [optional, Array] :filter ([]) An array of Hashes representing the filters. Note that the values in the hashes have to be arrays
       #
       def describe_tags( options = {} )
         params = {}
@@ -30,8 +39,16 @@ module AWS
 
       # The DeleteTags operation deletes tags for the specified resource(s).
       #
+      # @example Remove the name tag from instance i-123456789.
+      #   delete_tags(:resource_id => 'i-123456789',
+      #               :tag         => [{'Name' => nil}])
+      #
+      # @example Remove the name tag from instance i-123456789, but only if it's 'Test Instance'.
+      #   delete_tags(:resource_id => 'i-123456789',
+      #               :tag         => [{'Name' => 'Test Instance'}])
+      #
       # @option options [Array] :resource_id ([]) The ids of the resource(s) to tag
-      # @option options [Array] :tag ([]) An array of Hashes representing the tags { tag_name => tag_value }. If a value is given (instead of nil/empty string), then the tag is only deleted if it has this value
+      # @option options [Array] :tag ([]) An array of Hashes representing the tags as string name/value pairs. If a value is given (instead of <tt>nil</tt> or an empty string), then the tag is only deleted if it has the specified value
       #
       def delete_tags( options = {} )
         raise ArgumentError, "No :resource_id provided" if options[:resource_id].nil? || options[:resource_id].empty?

--- a/test/test_EC2_instances.rb
+++ b/test/test_EC2_instances.rb
@@ -38,6 +38,7 @@ context "EC2 instances " do
            <amiLaunchIndex>0</amiLaunchIndex>
           <instanceType>m1.small</instanceType>
           <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+          <clientToken>The client token</clientToken>
         </item>
         <item>
           <instanceId>i-2bc64242</instanceId>
@@ -52,6 +53,7 @@ context "EC2 instances " do
           <amiLaunchIndex>1</amiLaunchIndex>
           <instanceType>m1.small</instanceType>
           <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+          <clientToken>The client token</clientToken>
         </item>
         <item>
           <instanceId>i-2be64332</instanceId>
@@ -66,6 +68,7 @@ context "EC2 instances " do
           <amiLaunchIndex>2</amiLaunchIndex>
           <instanceType>m1.small</instanceType>
           <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+          <clientToken>The client token</clientToken>
         </item>
       </instancesSet>
     </RunInstancesResponse>
@@ -242,12 +245,12 @@ context "EC2 instances " do
 
 
   specify "should be able to be run" do
-    @ec2.stubs(:make_request).with('RunInstances', "ImageId" => "ami-60a54009", "MinCount" => '1', "MaxCount" => '1').
+    @ec2.stubs(:make_request).with('RunInstances', "ImageId" => "ami-60a54009", "MinCount" => '1', "MaxCount" => '1', "ClientToken" => 'The client token').
       returns stub(:body => @run_instances_response_body, :is_a? => true)
 
-    @ec2.run_instances( :image_id => "ami-60a54009" ).should.be.an.instance_of Hash
+    @ec2.run_instances( :image_id => "ami-60a54009", :client_token => 'The client token' ).should.be.an.instance_of Hash
 
-    response = @ec2.run_instances( :image_id => "ami-60a54009" )
+    response = @ec2.run_instances( :image_id => "ami-60a54009", :client_token => 'The client token' )
 
     response.reservationId.should.equal "r-47a5402e"
     response.ownerId.should.equal "495219933132"
@@ -263,6 +266,7 @@ context "EC2 instances " do
     response.instancesSet.item[0].keyName.should.equal "example-key-name"
     response.instancesSet.item[0].instanceType.should.equal "m1.small"
     response.instancesSet.item[0].launchTime.should.equal "2007-08-07T11:51:50.000Z"
+    response.instancesSet.item[0].clientToken.should.equal "The client token"
 
     response.instancesSet.item[1].instanceId.should.equal "i-2bc64242"
     response.instancesSet.item[1].imageId.should.equal "ami-60a54009"
@@ -273,6 +277,7 @@ context "EC2 instances " do
     response.instancesSet.item[1].keyName.should.equal "example-key-name"
     response.instancesSet.item[1].instanceType.should.equal "m1.small"
     response.instancesSet.item[1].launchTime.should.equal "2007-08-07T11:51:50.000Z"
+    response.instancesSet.item[1].clientToken.should.equal "The client token"
 
     response.instancesSet.item[2].instanceId.should.equal "i-2be64332"
     response.instancesSet.item[2].imageId.should.equal "ami-60a54009"
@@ -283,6 +288,7 @@ context "EC2 instances " do
     response.instancesSet.item[2].keyName.should.equal "example-key-name"
     response.instancesSet.item[2].instanceType.should.equal "m1.small"
     response.instancesSet.item[2].launchTime.should.equal "2007-08-07T11:51:50.000Z"
+    response.instancesSet.item[2].clientToken.should.equal "The client token"
   end
 
 


### PR DESCRIPTION
There’s a new client token option in the EC2 API that can be used to ensure instance launches are idempotent. This adds support for it and updates the applicable tests correspondingly.

I’m not sure why my pull request includes my merge of the upstream changes and I can’t figure out how to change the commit range to ignore them. It should merge cleanly either way, though, I think.
