### PR TITLE
describe_images now supports filtering

### DIFF
--- a/bin/awshell
+++ b/bin/awshell
@@ -12,8 +12,8 @@
 # CREDITS : Credit for this bit of shameful ripoff coolness
 # goes to Marcel Molina and his AWS::S3 gem.  Thanks!
 
-aws_lib   = File.dirname(__FILE__) + '/../lib/AWS'
-setup = File.dirname(__FILE__) + '/setup'
+aws_lib   = File.expand_path(File.dirname(__FILE__) + '/../lib/AWS')
+setup = File.expand_path(File.dirname(__FILE__) + '/setup')
 irb_name = RUBY_PLATFORM =~ /mswin32/ ? 'irb.bat' : 'irb'
 
 welcome_message = <<-MESSAGE

--- a/lib/AWS/EC2/images.rb
+++ b/lib/AWS/EC2/images.rb
@@ -130,16 +130,26 @@ module AWS
       #
       # Deregistered images will be included in the returned results for an unspecified interval subsequent to
       # deregistration.
+      # 
+      # The results can be filtered using the filter argument. The EC2 API reference for a full description of
+      # filter types and arguments.
+      # 
+      # @example 
+      #   @ec2.describe_images(:owner_id => ['self'], :filter => [{"tag:Role" => "App"}])
       #
       # @option options [Array] :image_id ([])
       # @option options [Array] :owner_id ([])
       # @option options [Array] :executable_by ([])
+      # @option options [Array] :filter ([])
       #
       def describe_images( options = {} )
         options = { :image_id => [], :owner_id => [], :executable_by => [] }.merge(options)
         params = pathlist( "ImageId", options[:image_id] )
         params.merge!(pathlist( "Owner", options[:owner_id] ))
         params.merge!(pathlist( "ExecutableBy", options[:executable_by] ))
+        if options[:filter]
+          params.merge!(pathkvlist('Filter', options[:filter], 'Name', 'Value', {}))
+        end
         return response_generator(:action => "DescribeImages", :params => params)
       end
 

--- a/lib/AWS/EC2/instances.rb
+++ b/lib/AWS/EC2/instances.rb
@@ -85,11 +85,21 @@ module AWS
       # Recently terminated instances will be included in the returned results for a small interval subsequent to
       # their termination. This interval is typically of the order of one hour
       #
+      # The results can be filtered using the filter argument. The EC2 API reference for a full description of
+      # filter types and arguments.
+      # 
+      # @example 
+      #   @ec2.describe_instances(:filter => [{"tag:Role" => "App"}])
+      # 
       # @option options [Array] :instance_id ([])
+      # @option options [Array<Hash>] :filter ([])
       #
       def describe_instances( options = {} )
         options = { :instance_id => [] }.merge(options)
         params = pathlist("InstanceId", options[:instance_id])
+        if options[:filter]
+          params.merge!(pathkvlist('Filter', options[:filter], 'Name', 'Value', {}))
+        end
         return response_generator(:action => "DescribeInstances", :params => params)
       end
 

--- a/lib/AWS/EC2/volumes.rb
+++ b/lib/AWS/EC2/volumes.rb
@@ -10,6 +10,9 @@ module AWS
       def describe_volumes( options = {} )
         options = { :volume_id => [] }.merge(options)
         params = pathlist("VolumeId", options[:volume_id] )
+        if options[:filter]
+          params.merge!(pathkvlist('Filter', options[:filter], 'Name', 'Value', {}))
+        end
         return response_generator(:action => "DescribeVolumes", :params => params)
       end
 


### PR DESCRIPTION
The newest version of the EC2 API supports some complex filtering for images. This adds some basic support for it as well as a line of documentation about it.
