### PR TITLE
Fix authorize security group ingress

### DIFF
--- a/lib/AWS/EC2/security_groups.rb
+++ b/lib/AWS/EC2/security_groups.rb
@@ -80,7 +80,7 @@ module AWS
       # @option options [optional, Integer] :to_port (nil) Required when authorizing CIDR IP permission
       # @option options [optional, String] :cidr_ip (nil) Required when authorizing CIDR IP permission
       # @option options [optional, String] :source_security_group_name (nil) Required when authorizing user group pair permissions
-      # @option options [optional, String] :source_security_group_owner_id (nil) Required when authorizing user group pair permissions
+      # @option options [optional, String] :source_security_group_user_id (nil) Required when authorizing user group pair permissions
       #
       def authorize_security_group_ingress( options = {} )
         options = { :group_name => nil,
@@ -89,20 +89,21 @@ module AWS
                     :to_port => nil,
                     :cidr_ip => nil,
                     :source_security_group_name => nil,
-                    :source_security_group_owner_id => nil }.merge(options)
+                    :source_security_group_user_id => nil }.merge(options)
 
         # lets not validate the rest of the possible permutations of required params and instead let
         # EC2 sort it out on the server side.  We'll only require :group_name as that is always needed.
         raise ArgumentError, "No :group_name provided" if options[:group_name].nil? || options[:group_name].empty?
 
         params = { "GroupName" => options[:group_name],
-                   "IpProtocol" => options[:ip_protocol],
-                   "FromPort" => options[:from_port].to_s,
-                   "ToPort" => options[:to_port].to_s,
-                   "CidrIp" => options[:cidr_ip],
-                   "SourceSecurityGroupName" => options[:source_security_group_name],
-                   "SourceSecurityGroupOwnerId" => options[:source_security_group_owner_id]
-                   }
+                   "IpPermissions.1.IpProtocol" => options[:ip_protocol],
+                   "IpPermissions.1.FromPort" => options[:from_port].to_s,
+                   "IpPermissions.1.ToPort" => options[:to_port].to_s,
+                   "IpPermissions.1.IpRanges.1" => options[:cidr_ip],
+                   "IpPermissions.1.Groups.1.GroupName" => options[:source_security_group_name],
+                   "IpPermissions.1.Groups.1.UserId" => options[:source_security_group_user_id]
+                 }
+
         return response_generator(:action => "AuthorizeSecurityGroupIngress", :params => params)
       end
 
@@ -131,7 +132,7 @@ module AWS
       # @option options [optional, Integer] :to_port (nil) Required when revoking CIDR IP permission
       # @option options [optional, String] :cidr_ip (nil) Required when revoking CIDR IP permission
       # @option options [optional, String] :source_security_group_name (nil) Required when revoking user group pair permissions
-      # @option options [optional, String] :source_security_group_owner_id (nil) Required when revoking user group pair permissions
+      # @option options [optional, String] :source_security_group_user_id (nil) Required when revoking user group pair permissions
       #
       def revoke_security_group_ingress( options = {} )
         options = { :group_name => nil,
@@ -140,20 +141,21 @@ module AWS
                     :to_port => nil,
                     :cidr_ip => nil,
                     :source_security_group_name => nil,
-                    :source_security_group_owner_id => nil }.merge(options)
+                    :source_security_group_user_id => nil }.merge(options)
 
         # lets not validate the rest of the possible permutations of required params and instead let
         # EC2 sort it out on the server side.  We'll only require :group_name as that is always needed.
         raise ArgumentError, "No :group_name provided" if options[:group_name].nil? || options[:group_name].empty?
 
         params = { "GroupName" => options[:group_name],
-                   "IpProtocol" => options[:ip_protocol],
-                   "FromPort" => options[:from_port].to_s,
-                   "ToPort" => options[:to_port].to_s,
-                   "CidrIp" => options[:cidr_ip],
-                   "SourceSecurityGroupName" => options[:source_security_group_name],
-                   "SourceSecurityGroupOwnerId" => options[:source_security_group_owner_id]
-                   }
+                   "IpPermissions.1.IpProtocol" => options[:ip_protocol],
+                   "IpPermissions.1.FromPort" => options[:from_port].to_s,
+                   "IpPermissions.1.ToPort" => options[:to_port].to_s,
+                   "IpPermissions.1.IpRanges.1" => options[:cidr_ip],
+                   "IpPermissions.1.Groups.1.GroupName" => options[:source_security_group_name],
+                   "IpPermissions.1.Groups.1.UserId" => options[:source_security_group_user_id]
+                 }
+
         return response_generator(:action => "RevokeSecurityGroupIngress", :params => params)
       end
 

--- a/test/test_EC2_security_groups.rb
+++ b/test/test_EC2_security_groups.rb
@@ -162,13 +162,14 @@ context "EC2 security groups " do
 
 
   specify "permissions should be able to be added to a security group with authorize_security_group_ingress." do
-    @ec2.stubs(:make_request).with('AuthorizeSecurityGroupIngress', { "GroupName"=>"WebServers",
-                                                                      "IpProtocol"=>"tcp",
-                                                                      "FromPort"=>"8000",
-                                                                      "ToPort"=>"80",
-                                                                      "CidrIp"=>"0.0.0.0/24",
-                                                                      "SourceSecurityGroupName"=>"Source SG Name",
-                                                                      "SourceSecurityGroupOwnerId"=>"123"}).
+    @ec2.stubs(:make_request).with('AuthorizeSecurityGroupIngress', 
+      { "GroupName" => "WebServers",
+        "IpPermissions.1.IpProtocol" => "tcp",
+        "IpPermissions.1.FromPort" => "8000",
+        "IpPermissions.1.ToPort" => "80",
+        "IpPermissions.1.IpRanges.1" => "0.0.0.0/24",
+        "IpPermissions.1.Groups.1.GroupName" => "Source SG Name", 
+        "IpPermissions.1.Groups.1.UserId" => "123"}).
       returns stub(:body => @authorize_security_group_ingress_response_body, :is_a? => true)
 
     @ec2.authorize_security_group_ingress( :group_name => "WebServers",
@@ -177,29 +178,30 @@ context "EC2 security groups " do
                                            :to_port => "80",
                                            :cidr_ip => "0.0.0.0/24",
                                            :source_security_group_name => "Source SG Name",
-                                           :source_security_group_owner_id => "123"
+                                           :source_security_group_user_id => "123"
                                            ).should.be.an.instance_of Hash
   end
 
 
   specify "permissions should be able to be revoked from a security group with revoke_security_group_ingress." do
-    @ec2.stubs(:make_request).with('RevokeSecurityGroupIngress', { "GroupName"=>"WebServers",
-                                                                   "IpProtocol"=>"tcp",
-                                                                   "FromPort"=>"8000",
-                                                                   "ToPort"=>"80",
-                                                                   "CidrIp"=>"0.0.0.0/24",
-                                                                   "SourceSecurityGroupName"=>"Source SG Name",
-                                                                   "SourceSecurityGroupOwnerId"=>"123"}).
+    @ec2.stubs(:make_request).with('RevokeSecurityGroupIngress',
+      { "GroupName" => "WebServers",
+        "IpPermissions.1.IpProtocol" => "tcp",
+        "IpPermissions.1.FromPort" => "8000",
+        "IpPermissions.1.ToPort" => "80",
+        "IpPermissions.1.IpRanges.1" => "0.0.0.0/24",
+        "IpPermissions.1.Groups.1.GroupName" => "Source SG Name", 
+        "IpPermissions.1.Groups.1.UserId" => "123"}).
       returns stub(:body => @revoke_security_group_ingress_response_body, :is_a? => true)
 
     @ec2.revoke_security_group_ingress( :group_name => "WebServers",
-                                        :ip_protocol => "tcp",
-                                        :from_port => "8000",
-                                        :to_port => "80",
-                                        :cidr_ip => "0.0.0.0/24",
-                                        :source_security_group_name => "Source SG Name",
-                                        :source_security_group_owner_id => "123"
-                                        ).should.be.an.instance_of Hash
+                                           :ip_protocol => "tcp",
+                                           :from_port => "8000",
+                                           :to_port => "80",
+                                           :cidr_ip => "0.0.0.0/24",
+                                           :source_security_group_name => "Source SG Name",
+                                           :source_security_group_user_id => "123"
+                                      ).should.be.an.instance_of Hash
   end
 
 end


### PR DESCRIPTION
I was trying to implement "smart" port filtering in EC2 by specifying the security group name in the AWS console by that seems to be broken ("Save" button gets disabled). I then tried amazon-ec2 and got error messages (conflict between parameters). Looking at the most recent API the call seems to have changed. I updated the Authorize and Revoke methods to match the new API and managed to get the calls working. The data shows up correctly in the AWS console (still can't add other thru the console though :(). Modified the tests to match the new API. Use as such in awshell (ids were edited):

ruby-1.9.2-p0 :001 > r = @ec2.revoke_security_group_ingress :group_name => 'MongoDB', :ip_protocol => "tcp", :from_port => "27017", :to_port => "27017", :source_security_group_user_id => '6530123210223', :source_security_group_name => 'MongoDB'
 => {"xmlns"=>"http://ec2.amazonaws.com/doc/2010-08-31/", "requestId"=>"994023423d-5a49-443e-be5e-01899a806149", "return"=>"true"}
