### PR TITLE
Changes ENV Variable Naming and Pulls it in as a default if AWS creds are not provided

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,8 +65,8 @@ Edit the file ~/.bash_login and add the following to the existing contents:
   export RUBYOPT="rubygems"
 
   # For amazon-ec2 and amazon s3 ruby gems
-  export AMAZON_ACCESS_KEY_ID="YOUR_ACCESS_KEY_ID"
-  export AMAZON_SECRET_ACCESS_KEY="YOUR_SECRET_ACCESS_KEY_ID"
+  export AWS_ACCESS_KEY_ID="YOUR_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="YOUR_SECRET_ACCESS_KEY_ID"
 
 If you are using EC2 in the EU region, make sure you also set:
 

--- a/bin/awshell
+++ b/bin/awshell
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+require 'rubygems' if RUBY_VERSION < '1.9'
+require 'irb'
+
 # Amazon Web Services EC2 Query API Ruby library
 #
 # Ruby Gem Name::  amazon-ec2
@@ -12,70 +15,71 @@
 # CREDITS : Credit for this bit of shameful ripoff coolness
 # goes to Marcel Molina and his AWS::S3 gem.  Thanks!
 
-aws_lib   = File.dirname(__FILE__) + '/../lib/AWS'
+require File.dirname(__FILE__) + '/../lib/AWS'
+
 setup = File.dirname(__FILE__) + '/setup'
-irb_name = RUBY_PLATFORM =~ /mswin32/ ? 'irb.bat' : 'irb'
 
-welcome_message = <<-MESSAGE
+def welcome!
+  puts <<-MESSAGE
 
-Usage :
+  Usage :
 
-This is an interactive Ruby 'irb' shell that allows you to use the
-AWS commands available in the 'amazon-ec2' gem.  This can be a
-great tool to help you debug issues and run commands
-against the live AWS servers.  You can do anything in this
-shell that you can in a normal irb shell.
+  This is an interactive Ruby 'irb' shell that allows you to use the
+  AWS commands available in the 'amazon-ec2' gem.  This can be a
+  great tool to help you debug issues and run commands
+  against the live AWS servers.  You can do anything in this
+  shell that you can in a normal irb shell.
 
-Config :
+  Config :
 
-You must set the following environment variables that contain your
-AWS credentials in your system shell for this to work.
+  You must set the following environment variables that contain your
+  AWS credentials in your system shell for this to work.
 
-  AMAZON_ACCESS_KEY_ID
-  AMAZON_SECRET_ACCESS_KEY
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
 
-Each AWS service has its own default server endpoints. You can override
-the endpoints with the following environment variables set in your
-system shell:
+  Each AWS service has its own default server endpoints. You can override
+  the endpoints with the following environment variables set in your
+  system shell:
 
-  EC2 :                     EC2_URL
-  Elastic Load Balancing :  ELB_URL
-  AutoScaling :             AS_URL
-  RDS :                     RDS_URL
-  CloudWatch :              AWS_CLOUDWATCH_URL
+    EC2 :                     EC2_URL
+    Elastic Load Balancing :  ELB_URL
+    AutoScaling :             AS_URL
+    RDS :                     RDS_URL
+    CloudWatch :              AWS_CLOUDWATCH_URL
 
-For your convenience, the various AWS services are wired up in this shell
-to the following class variables.  You can execute methods on each of these:
+  For your convenience, the various AWS services are wired up in this shell
+  to the following class variables.  You can execute methods on each of these:
 
-  @ec2   (Elastic Compute Cloud)
-  @elb   (Elastic Load Balancing)
-  @as    (AutoScaling)
-  @rds   (Relational Database Service)
-  @cw    (CloudWatch)
+    @ec2   (Elastic Compute Cloud)
+    @elb   (Elastic Load Balancing)
+    @as    (AutoScaling)
+    @rds   (Relational Database Service)
+    @cw    (CloudWatch)
 
-You can make method calls on these instances to execute commands against
-the various services. Pre-pending a 'pp' should give you a pretty printed
-version of the response which may be easier to read.
+  You can make method calls on these instances to execute commands against
+  the various services. Pre-pending a 'pp' should give you a pretty printed
+  version of the response which may be easier to read.
 
-Examples:
+  Examples:
 
-  returns : Pretty Print all ec2 public methods
-  >> pp @ec2.methods.sort
+    returns : Pretty Print all ec2 public methods
+    >> pp @ec2.methods.sort
 
-  returns : Pretty Print a Hash describing your EC2 images
-  >> @ec2.describe_images(:owner_id => ['self'])
+    returns : Pretty Print a Hash describing your EC2 images
+    >> @ec2.describe_images(:owner_id => ['self'])
 
-  returns : an Array of AWS::Response objects, each an EC2 image and its data
-  >> @ec2.describe_images(:owner_id => ['self']).imagesSet.item
-  >> @ec2.describe_images(:owner_id => ['self']).imagesSet.item[0]
-
+    returns : an Array of AWS::Response objects, each an EC2 image and its data
+    >> @ec2.describe_images(:owner_id => ['self']).imagesSet.item
+    >> @ec2.describe_images(:owner_id => ['self']).imagesSet.item[0]
 MESSAGE
-
-if ( ENV['AMAZON_ACCESS_KEY_ID'] && ENV['AMAZON_SECRET_ACCESS_KEY'] )
-  puts welcome_message
-  exec "#{irb_name} -rubygems -r #{aws_lib} -r #{setup} --simple-prompt"
-else
-  puts "You must define AMAZON_ACCESS_KEY_ID and AMAZON_SECRET_ACCESS_KEY as shell environment variables before running #{$0}!"
-  puts welcome_message
 end
 
+if((ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY']) || (ENV['AMAZON_ACCESS_KEY_ID'] && ENV['AMAZON_SECRET_ACCESS_KEY']))
+  puts "Please type 'welcome!' for an introduction on amazon-ec2"
+  IRB.start
+  require setup
+else
+  puts "You must define AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as shell environment variables before running #{$0}!"
+  puts welcome!
+end

--- a/bin/ec2-gem-example.rb
+++ b/bin/ec2-gem-example.rb
@@ -18,14 +18,14 @@ require 'pp'
 # e.g. in ~/.bash_login
 #
 #  # For amazon-ec2 and amazon s3 ruby gems
-#  export AMAZON_ACCESS_KEY_ID="FOO"
-#  export AMAZON_SECRET_ACCESS_KEY="BAR"
+#  export AWS_SECRET_ACCESS_KEY="FOO"
+#  export AWS_SECRET_ACCESS_KEY="BAR"
 
-ACCESS_KEY_ID = ENV['AMAZON_ACCESS_KEY_ID']
-SECRET_ACCESS_KEY = ENV['AMAZON_SECRET_ACCESS_KEY']
+ACCESS_KEY_ID     = ENV['AWS_ACCESS_KEY_ID']      || ENV['AMAZON_ACCESS_KEY_ID']
+SECRET_ACCESS_KEY = ENV['AWS_SECRET_ACCESS_KEY']  || ENV['AMAZON_SECRET_ACCESS_KEY']
 
 if ACCESS_KEY_ID.nil? || ACCESS_KEY_ID.empty?
-  puts "Error : You must add the shell environment variables AMAZON_ACCESS_KEY_ID and AMAZON_SECRET_ACCESS_KEY before calling #{$0}!"
+  puts "Error : You must add the shell environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY before calling #{$0}!"
   exit
 end
 

--- a/bin/ec2-gem-profile.rb
+++ b/bin/ec2-gem-profile.rb
@@ -3,8 +3,9 @@
 # Basic single command application that we can call with perftools.rb to get consistent results.
 
 require File.dirname(__FILE__) + '/../lib/AWS'
-ACCESS_KEY_ID = ENV['AMAZON_ACCESS_KEY_ID']
-SECRET_ACCESS_KEY = ENV['AMAZON_SECRET_ACCESS_KEY']
-ec2 = AWS::EC2::Base.new( :access_key_id => ACCESS_KEY_ID, :secret_access_key => SECRET_ACCESS_KEY )
-@images = ec2.describe_images
+ACCESS_KEY_ID     = ENV['AWS_ACCESS_KEY_ID']      || ENV['AMAZON_ACCESS_KEY_ID']
+SECRET_ACCESS_KEY = ENV['AWS_SECRET_ACCESS_KEY']  || ENV['AMAZON_SECRET_ACCESS_KEY']
 
+ec2 = AWS::EC2::Base.new( :access_key_id => ACCESS_KEY_ID, :secret_access_key => SECRET_ACCESS_KEY )
+
+@images = ec2.describe_images

--- a/bin/setup.rb
+++ b/bin/setup.rb
@@ -9,11 +9,13 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-if ENV['AMAZON_ACCESS_KEY_ID'] && ENV['AMAZON_SECRET_ACCESS_KEY']
+
+
+if(AWS::ACCESS_KEY_ID and AWS::SECRET_ACCESS_KEY)
 
   opts = {
-    :access_key_id => ENV['AMAZON_ACCESS_KEY_ID'],
-    :secret_access_key => ENV['AMAZON_SECRET_ACCESS_KEY']
+    :access_key_id      => AWS::ACCESS_KEY_ID,
+    :secret_access_key  => AWS::SECRET_ACCESS_KEY
   }
 
   if ENV['EC2_URL']

--- a/lib/AWS.rb
+++ b/lib/AWS.rb
@@ -50,6 +50,8 @@ end
 
 
 module AWS
+  ACCESS_KEY_ID     = ENV['AWS_ACCESS_KEY_ID']      || ENV['AMAZON_ACCESS_KEY_ID']      || ""
+  SECRET_ACCESS_KEY = ENV['AWS_SECRET_ACCESS_KEY']  || ENV['AMAZON_SECRET_ACCESS_KEY']  || ""
 
   # Builds the canonical string for signing requests. This strips out all '&', '?', and '='
   # from the query string to be signed.  The parameters in the path passed in must already
@@ -111,7 +113,6 @@ module AWS
   # interface. You should not instantiate this directly, instead
   # you should setup an instance of 'AWS::EC2::Base' or 'AWS::ELB::Base'.
   class Base
-
     attr_reader :use_ssl, :server, :proxy_server, :port
 
     # @option options [String] :access_key_id ("") The user's AWS Access Key ID
@@ -122,8 +123,8 @@ module AWS
     # @return [Object] the object.
     def initialize( options = {} )
 
-      options = { :access_key_id => "",
-                  :secret_access_key => "",
+      options = { :access_key_id => ACCESS_KEY_ID,
+                  :secret_access_key => SECRET_ACCESS_KEY,
                   :use_ssl => true,
                   :server => default_host,
                   :path => "/",


### PR DESCRIPTION
ENV Variables are now the same as what Amazon uses, while still allowing the old ones to be used--to avoid breaking scripts.

In addition, doing this:

ec2 = AWS::EC2::Base.new

works, because the credentials are pulled in, if they exist, at load time.
