### PR TITLE
Fix relative-path inclusion to work with Ruby 1.9.2 and later.

### DIFF
--- a/test/test_Autoscaling_groups.rb
+++ b/test/test_Autoscaling_groups.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "autoscaling " do
   before do

--- a/test/test_EC2.rb
+++ b/test/test_EC2.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "The EC2 method " do
 

--- a/test/test_EC2_availability_zones.rb
+++ b/test/test_EC2_availability_zones.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 availability zones" do
 

--- a/test/test_EC2_console.rb
+++ b/test/test_EC2_console.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "The EC2 console " do
 

--- a/test/test_EC2_elastic_ips.rb
+++ b/test/test_EC2_elastic_ips.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 elastic IP addresses " do
 

--- a/test/test_EC2_image_attributes.rb
+++ b/test/test_EC2_image_attributes.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 image_attributes " do
 

--- a/test/test_EC2_images.rb
+++ b/test/test_EC2_images.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "An EC2 image " do
 

--- a/test/test_EC2_instances.rb
+++ b/test/test_EC2_instances.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 instances " do
 

--- a/test/test_EC2_keypairs.rb
+++ b/test/test_EC2_keypairs.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 keypairs " do
 

--- a/test/test_EC2_password.rb
+++ b/test/test_EC2_password.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "The EC2 password " do
 

--- a/test/test_EC2_products.rb
+++ b/test/test_EC2_products.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "An EC2 instance " do
 

--- a/test/test_EC2_responses.rb
+++ b/test/test_EC2_responses.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "The Response classes " do
 

--- a/test/test_EC2_s3_xmlsimple.rb
+++ b/test/test_EC2_s3_xmlsimple.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 # NOTE : These tests exercise amazon-ec2 when used with the aws/s3 gem
 # which was demonstrating some breaking behavior.  The fix was to

--- a/test/test_EC2_security_groups.rb
+++ b/test/test_EC2_security_groups.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 security groups " do
 

--- a/test/test_EC2_snapshots.rb
+++ b/test/test_EC2_snapshots.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 snaphots " do
 

--- a/test/test_EC2_spot_instance_requests.rb
+++ b/test/test_EC2_spot_instance_requests.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "An EC2 spot instances request " do
 

--- a/test/test_EC2_spot_prices.rb
+++ b/test/test_EC2_spot_prices.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "Spot price history " do
 

--- a/test/test_EC2_subnets.rb
+++ b/test/test_EC2_subnets.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "The EC2 subnets " do
 

--- a/test/test_EC2_volumes.rb
+++ b/test/test_EC2_volumes.rb
@@ -8,7 +8,7 @@
 # Home::      http://github.com/grempe/amazon-ec2/tree/master
 #++
 
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "EC2 volumes " do
 

--- a/test/test_ELB_load_balancers.rb
+++ b/test/test_ELB_load_balancers.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "elb load balancers " do
   before do

--- a/test/test_RDS.rb
+++ b/test/test_RDS.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper.rb'
+require File.expand_path('../test_helper.rb', __FILE__)
 
 context "rds databases " do
   before do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,5 +19,5 @@ gem 'test-unit'
   end
 }
 
-require File.dirname(__FILE__) + '/../lib/AWS'
+require File.expand_path('../../lib/AWS', __FILE__)
 


### PR DESCRIPTION
Hello,

this patch is required for amazon-ec2 to run its tests properly on Ruby 1.9.2 with the new load path handling.

HTH,
Diego
