### PR TITLE
add license information to the gemspec

### DIFF
--- a/amazon-ec2.gemspec
+++ b/amazon-ec2.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.license = "Ruby"
 end
 


### PR DESCRIPTION
This way it can be queried using the rubygems.org API
